### PR TITLE
Refine output description in tasks.yaml for learning advice task

### DIFF
--- a/src/note_eval/config/tasks.yaml
+++ b/src/note_eval/config/tasks.yaml
@@ -21,5 +21,5 @@ learning_advice_task:
   expected_output: >
     1. The exact summary of the inital note from previous steps.
     2. The exact comment output of the online comparison made.
-    3. A suggestion for the next learning topic, along with a short explanation.
+    3. Suggestion for the next learning topic, along with a short explanation.
   agent: learning_advisor


### PR DESCRIPTION
Under learning_advice_task i changed the sentence under the expected output from : "A Suggestion for the next learning" topic to "Suggestion for the next learning topic"